### PR TITLE
Fix comma style

### DIFF
--- a/math_keyboard/CHANGELOG.md
+++ b/math_keyboard/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+1
+
+* Fixed styling of commas as decimal separators.
+
 ## 0.1.0
 
 * Initial public version.

--- a/math_keyboard/lib/src/widgets/math_field.dart
+++ b/math_keyboard/lib/src/widgets/math_field.dart
@@ -570,7 +570,11 @@ class _FieldPreview extends StatelessWidget {
           // that can simply be replaced by an alternate decimal separator
           // for the preview.
           '.',
-          decimalSeparator(context),
+          // We need to wrap the decimal separator in an extra group ("{}")
+          // because commas will otherwise be spaced as if they created a
+          // list, e.g. in vector notation (there is a padding to the right
+          // of the comma).
+          '{${decimalSeparator(context)}}',
         );
 
     return ConstrainedBox(

--- a/math_keyboard/pubspec.yaml
+++ b/math_keyboard/pubspec.yaml
@@ -2,7 +2,7 @@ name: math_keyboard
 description: >-2
   Math expression editing using an on-screen software keyboard or physical keyboard input in a
   typeset input field in Flutter.
-version: 0.1.0
+version: 0.1.0+1
 homepage: https://github.com/simpleclub/math_keyboard/tree/main/math_keyboard
 
 environment:


### PR DESCRIPTION
## Description

Previously, the comma styling looked like this:

<img width="577" alt="Screen Shot 2021-03-20 at 12 50 52" src="https://user-images.githubusercontent.com/19204050/111870261-947af180-897b-11eb-9481-ca616d29da0c.png">

This PR removes the padding and makes it look proper.

## Checklist

*Remove `If [...]` items that do not apply to your PR.*

- [x] I have made myself familiar with the CaTeX
      [contributing guide](https://github.com/simpleclub/math_keyboard/blob/master/CONTRIBUTING.md).
- [x] I added a PR description.
- [x] I linked all related issues and PRs I could find (no links if there are none).
- [x] If this PR changes anything about the main `math_keyboard` or `example` package
      (also README etc.), I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change
      on its own is not worth an update).
- [x] If this PR includes a notable change in the `math_keyboard` package, I updated the version
        according to [Dart's semantic versioning](https://stackoverflow.com/questions/66201337/how-do-dart-package-versions-work-how-should-i-version-my-flutter-plugins/66201338#66201338).
- [x] If there is new functionality in code, I added tests covering all my additions.
- [x] All required checks pass.
