### PR TITLE
SC-4183 convertMathExpressionToTeXNode does not keep parentheses

### DIFF
--- a/math_keyboard/lib/src/foundation/math2tex.dart
+++ b/math_keyboard/lib/src/foundation/math2tex.dart
@@ -24,8 +24,9 @@ List<TeX> _convertToTeX(Expression mathExpression, TeXNode parent) {
     ];
   }
   if (mathExpression is BinaryOperator) {
+    List<TeX>? result;
     if (mathExpression is Divide) {
-      return [
+      result = [
         TeXFunction(
           r'\frac',
           parent,
@@ -37,29 +38,29 @@ List<TeX> _convertToTeX(Expression mathExpression, TeXNode parent) {
         ),
       ];
     }
-    if (mathExpression is Plus) {
-      return [
+    else if (mathExpression is Plus) {
+      result = [
         ..._convertToTeX(mathExpression.first, parent),
         const TeXLeaf('+'),
         ..._convertToTeX(mathExpression.second, parent),
       ];
     }
-    if (mathExpression is Minus) {
-      return [
+    else if (mathExpression is Minus) {
+      result = [
         ..._convertToTeX(mathExpression.first, parent),
         const TeXLeaf('-'),
         ..._convertToTeX(mathExpression.second, parent),
       ];
     }
-    if (mathExpression is Times) {
-      return [
+    else if (mathExpression is Times) {
+      result = [
         ..._convertToTeX(mathExpression.first, parent),
         const TeXLeaf(r'\cdot'),
         ..._convertToTeX(mathExpression.second, parent),
       ];
     }
-    if (mathExpression is Power) {
-      return [
+    else if (mathExpression is Power) {
+      result = [
         ..._convertToTeX(mathExpression.first, parent),
         TeXFunction(
           '^',
@@ -69,8 +70,16 @@ List<TeX> _convertToTeX(Expression mathExpression, TeXNode parent) {
         ),
       ];
     }
-    // Note that modulo is unsupported.
-    throw UnimplementedError();
+    if (result == null) {
+      // Note that modulo is unsupported.
+      throw UnimplementedError();
+    }
+    // Wrap with parentheses to keep precedence.
+    return [
+      TeXLeaf('('),
+      ...result,
+      TeXLeaf(')'),
+    ];
   }
   if (mathExpression is Literal) {
     if (mathExpression is Number) {

--- a/math_keyboard/lib/src/foundation/math2tex.dart
+++ b/math_keyboard/lib/src/foundation/math2tex.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:math_expressions/math_expressions.dart';
 import 'package:math_keyboard/src/foundation/node.dart';
 
@@ -37,29 +39,25 @@ List<TeX> _convertToTeX(Expression mathExpression, TeXNode parent) {
           ],
         ),
       ];
-    }
-    else if (mathExpression is Plus) {
+    } else if (mathExpression is Plus) {
       result = [
         ..._convertToTeX(mathExpression.first, parent),
         const TeXLeaf('+'),
         ..._convertToTeX(mathExpression.second, parent),
       ];
-    }
-    else if (mathExpression is Minus) {
+    } else if (mathExpression is Minus) {
       result = [
         ..._convertToTeX(mathExpression.first, parent),
         const TeXLeaf('-'),
         ..._convertToTeX(mathExpression.second, parent),
       ];
-    }
-    else if (mathExpression is Times) {
+    } else if (mathExpression is Times) {
       result = [
         ..._convertToTeX(mathExpression.first, parent),
         const TeXLeaf(r'\cdot'),
         ..._convertToTeX(mathExpression.second, parent),
       ];
-    }
-    else if (mathExpression is Power) {
+    } else if (mathExpression is Power) {
       result = [
         ..._convertToTeX(mathExpression.first, parent),
         TeXFunction(
@@ -84,6 +82,12 @@ List<TeX> _convertToTeX(Expression mathExpression, TeXNode parent) {
   if (mathExpression is Literal) {
     if (mathExpression is Number) {
       final number = mathExpression.value as double;
+      if (number == math.pi) {
+        return [TeXLeaf(r'\pi')];
+      }
+      if (number == math.e) {
+        return [TeXLeaf('e')];
+      }
       final adjusted = number.toInt() == number ? number.toInt() : number;
       return [
         for (final symbol in adjusted.toString().split('')) TeXLeaf(symbol),

--- a/math_keyboard/lib/src/foundation/math2tex.dart
+++ b/math_keyboard/lib/src/foundation/math2tex.dart
@@ -83,10 +83,10 @@ List<TeX> _convertToTeX(Expression mathExpression, TeXNode parent) {
     if (mathExpression is Number) {
       final number = mathExpression.value as double;
       if (number == math.pi) {
-        return [TeXLeaf(r'\pi')];
+        return [TeXLeaf(r'{\pi}')];
       }
       if (number == math.e) {
-        return [TeXLeaf('e')];
+        return [TeXLeaf('{e}')];
       }
       final adjusted = number.toInt() == number ? number.toInt() : number;
       return [

--- a/math_keyboard/lib/src/foundation/tex2math.dart
+++ b/math_keyboard/lib/src/foundation/tex2math.dart
@@ -290,7 +290,11 @@ class TeXParser {
         case '-':
           right = result.removeLast();
           left = result.removeLast();
-          result.add(left - right);
+          if (left.toString() == '0') {
+            result.add(-right);
+          } else {
+            result.add(left - right);
+          }
           break;
         case r'\times':
         case r'\cdot':

--- a/math_keyboard/pubspec.yaml
+++ b/math_keyboard/pubspec.yaml
@@ -2,7 +2,7 @@ name: math_keyboard
 description: >-2
   Math expression editing using an on-screen software keyboard or physical keyboard input in a
   typeset input field in Flutter.
-version: 0.1.0+1
+version: 0.1.0+2
 homepage: https://github.com/simpleclub/math_keyboard/tree/main/math_keyboard
 
 environment:

--- a/math_keyboard/test/foundation/math2tex_test.dart
+++ b/math_keyboard/test/foundation/math2tex_test.dart
@@ -8,7 +8,6 @@ import 'package:math_keyboard/src/foundation/tex2math.dart';
 // todo: refactor the conversion to enable sensible tests.
 void main() {
   group('constants', () {
-
     test('pi', () {
       final node = convertMathExpressionToTeXNode(Parser().parse('$pi'));
       expect(node.children[0].expression, r'{\pi}');

--- a/math_keyboard/test/foundation/math2tex_test.dart
+++ b/math_keyboard/test/foundation/math2tex_test.dart
@@ -8,7 +8,18 @@ import 'package:math_keyboard/src/foundation/tex2math.dart';
 // todo: refactor the conversion to enable sensible tests.
 void main() {
   group('constants', () {
+
     test('pi', () {
+      final node = convertMathExpressionToTeXNode(Parser().parse('$pi'));
+      expect(node.children[0].expression, r'{\pi}');
+    });
+
+    test('e', () {
+      final node = convertMathExpressionToTeXNode(Parser().parse('$e'));
+      expect(node.children[0].expression, r'{e}');
+    });
+
+    test('pi2', () {
       const tex = r'23+{\pi}+{x}';
       const exp = '23+$pi+x';
       expect(
@@ -20,7 +31,7 @@ void main() {
       );
     });
 
-    test('e', () {
+    test('e2', () {
       const tex = '{x}+{e}^2';
       const exp = 'x+$e^2';
       expect(

--- a/math_keyboard_demo/lib/widgets/page_view.dart
+++ b/math_keyboard_demo/lib/widgets/page_view.dart
@@ -227,8 +227,7 @@ class _PrimaryPage extends StatefulWidget {
 
 class _PrimaryPageState extends State<_PrimaryPage> {
   late final _expressionController = MathFieldEditingController()
-    ..updateValue(
-        Parser().parse('4.2 - (cos(x)/(x^3 - sin(x))) + e^(4^2)'));
+    ..updateValue(Parser().parse('4.2 - (cos(x)/(x^3 - sin(x))) + e^(4^2)'));
   late final _numberController = MathFieldEditingController()
     ..updateValue(Parser().parse('42'));
 


### PR DESCRIPTION
## Description

Adds parentheses for binary operators, when converting a `math_expression` to a `tex ast`.
Adds special cases for `pi` and `e` when converting a `math_expression` to a `tex ast`.
Removes the leading zero from an unary minus when converting `tex` into a `math_expression`.

## Related issues & PRs

https://simpleclub.atlassian.net/browse/SC-4183

## Checklist

*Remove `If [...]` items that do not apply to your PR.*

- [x] I have made myself familiar with the CaTeX
      [contributing guide](https://github.com/simpleclub/math_keyboard/blob/master/CONTRIBUTING.md).
- [x] I added a PR description.
- [x] I linked all related issues and PRs I could find (no links if there are none).
- [x] If this PR changes anything about the main `math_keyboard` or `example` package
      (also README etc.), I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change
      on its own is not worth an update).
- [x] If this PR includes a notable change in the `math_keyboard` package, I updated the version
        according to [Dart's semantic versioning](https://stackoverflow.com/questions/66201337/how-do-dart-package-versions-work-how-should-i-version-my-flutter-plugins/66201338#66201338).
- [x] If there is new functionality in code, I added tests covering all my additions.
- [x] All required checks pass.
