### PR TITLE
Implicit times between parentheses

### DIFF
--- a/math_keyboard/CHANGELOG.md
+++ b/math_keyboard/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4
+
+* Fixed missing implicit times operator between a closing and an opening parenthesis. 
+
 ## 0.1.3
 
 * Added new symbols icon for functions button.

--- a/math_keyboard/lib/src/foundation/tex2math.dart
+++ b/math_keyboard/lib/src/foundation/tex2math.dart
@@ -129,7 +129,7 @@ class TeXParser {
 
     for (var i = 0; i < _stream.length; i++) {
       /// wrong syntax: fr fo lr lo oo (b/r postfix or wrong)
-      /// need times: bb bf bl rb rf !f !l
+      /// need times: bb bf bl rb rf rl !f !l
       /// negative number: -(bfl) / l-(bfl)
 
       // negative number
@@ -164,6 +164,7 @@ class TeXParser {
         switch (_stream[i + 1][1]) {
           case 'b':
           case 'f':
+          case 'l':
             _stream.insert(i + 1, [
               r'\times',
               ['o', 3, 'l'],

--- a/math_keyboard/pubspec.yaml
+++ b/math_keyboard/pubspec.yaml
@@ -2,7 +2,7 @@ name: math_keyboard
 description: >-2
   Math expression editing using an on-screen software keyboard or physical keyboard input in a
   typeset input field in Flutter.
-version: 0.1.3
+version: 0.1.4
 homepage: https://github.com/simpleclub/math_keyboard/tree/main/math_keyboard
 
 environment:

--- a/math_keyboard/test/foundation/tex2math_test.dart
+++ b/math_keyboard/test/foundation/tex2math_test.dart
@@ -65,6 +65,15 @@ void main() {
         Parser().parse(exp).toString(),
       );
     });
+
+    test('implicit3', () {
+      const tex = '23^{2}({c})';
+      const exp = '23^2*c';
+      expect(
+        TeXParser(tex).parse().toString(),
+        Parser().parse(exp).toString(),
+      );
+    });
   });
 
   group('frac', () {
@@ -158,6 +167,15 @@ void main() {
     test('squareRoot', () {
       const tex = r'2 \times  \sqrt{{x}}';
       const exp = '2*nrt(2,x)';
+      expect(
+        TeXParser(tex).parse().toString(),
+        Parser().parse(exp).toString(),
+      );
+    });
+
+    test('nRoot', () {
+      const tex = r'2 \times  \sqrt[3]{{x}}';
+      const exp = '(2.0 * (x^(1.0 / 3.0)))';
       expect(
         TeXParser(tex).parse().toString(),
         Parser().parse(exp).toString(),

--- a/math_keyboard/test/foundation/tex2math_test.dart
+++ b/math_keyboard/test/foundation/tex2math_test.dart
@@ -56,6 +56,15 @@ void main() {
         Parser().parse(exp).toString(),
       );
     });
+
+    test('implicit2', () {
+      const tex = '(23)({c})';
+      const exp = '23*c';
+      expect(
+        TeXParser(tex).parse().toString(),
+        Parser().parse(exp).toString(),
+      );
+    });
   });
 
   group('frac', () {


### PR DESCRIPTION
## Description

The `TexParser` did not consider an implicit times between a closing and an opening parenthesis.
Examples for such cases:
- `(1-x)(1+x)`
- `\\frac{1}{2}(25)`
- `e^{x}(1+x)`

## Checklist

*Remove `If [...]` items that do not apply to your PR.*

- [x] I have made myself familiar with the CaTeX
      [contributing guide](https://github.com/simpleclub/math_keyboard/blob/master/CONTRIBUTING.md).
- [x] I added a PR description.
- [x] I linked all related issues and PRs I could find (no links if there are none).
- [x] If this PR changes anything about the main `math_keyboard` or `example` package
      (also README etc.), I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change
      on its own is not worth an update).
- [x] If this PR includes a notable change in the `math_keyboard` package, I updated the version
        according to [Dart's semantic versioning](https://stackoverflow.com/questions/66201337/how-do-dart-package-versions-work-how-should-i-version-my-flutter-plugins/66201338#66201338).
- [x] If there is new functionality in code, I added tests covering all my additions.
- [x] All required checks pass.
