### PR TITLE
Cursor update SC-4607

### DIFF
--- a/math_keyboard/CHANGELOG.md
+++ b/math_keyboard/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.5
+
+* Updated field cursor using `\cursor` function from `flutter_math_fork 0.6.2`.
+
 ## 0.1.4+1
 
 * Bumped `flutter_math_fork`.

--- a/math_keyboard/lib/src/foundation/node.dart
+++ b/math_keyboard/lib/src/foundation/node.dart
@@ -203,10 +203,7 @@ abstract class TeX {
 /// Class describing the cursor as a TeX expression.
 class Cursor extends TeX {
   /// Creates a TeX [Cursor].
-  const Cursor()
-      :
-        // todo: clean this up.
-        super('');
+  const Cursor() : super('');
 
   @override
   String buildString({required Color? cursorColor}) {
@@ -215,7 +212,7 @@ class Cursor extends TeX {
     }
     final colorString =
         '#${(cursorColor.value & 0xFFFFFF).toRadixString(16).padLeft(6, '0')}';
-    return '\\textcolor{$colorString}{|}';
+    return '\\textcolor{$colorString}{\\cursor}';
   }
 }
 

--- a/math_keyboard/lib/src/widgets/math_field.dart
+++ b/math_keyboard/lib/src/widgets/math_field.dart
@@ -599,7 +599,7 @@ class _FieldPreview extends StatelessWidget {
                     // This is a workaround for aligning the cursor properly
                     // when the math field is empty. This way it matches the
                     // TextField behavior.
-                    : Offset(-4, 0),
+                    : Offset(-1, 0),
                 child: Math.tex(
                   tex,
                   options: MathOptions(

--- a/math_keyboard/pubspec.yaml
+++ b/math_keyboard/pubspec.yaml
@@ -2,7 +2,7 @@ name: math_keyboard
 description: >-2
   Math expression editing using an on-screen software keyboard or physical keyboard input in a
   typeset input field in Flutter.
-version: 0.1.4+1
+version: 0.1.5
 homepage: https://github.com/simpleclub/math_keyboard/tree/main/math_keyboard
 
 environment:
@@ -15,7 +15,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  flutter_math_fork: ^0.6.1
+  flutter_math_fork: ^0.6.2
   holding_gesture: ^1.1.0
   intl: ^0.17.0
   math_expressions: ^2.1.0

--- a/math_keyboard_demo/pubspec.lock
+++ b/math_keyboard_demo/pubspec.lock
@@ -38,7 +38,7 @@ packages:
       name: flutter_math_fork
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1"
+    version: "0.6.2"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -99,7 +99,7 @@ packages:
       path: "../math_keyboard"
       relative: true
     source: path
-    version: "0.1.4+1"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description

- Use an updated version of flutter_math_fork 0.6.2 that introduces `CursorNode` and `\cursor` function
- Replace Cursor implementation via `|` symbol with `\cursor`
- Updated empty field offset dx from -4 to -1, since `\cursor` has smaller horizontal paddings

## Related issues & PRs

https://simpleclub.atlassian.net/browse/SC-4607

## Checklist

- [x] I have made myself familiar with the CaTeX
      [contributing guide](https://github.com/simpleclub/math_keyboard/blob/master/CONTRIBUTING.md).
- [x] I added a PR description.
- [x] I linked all related issues and PRs I could find (no links if there are none).
- [x] If this PR changes anything about the main `math_keyboard` or `example` package
      (also README etc.), I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change
      on its own is not worth an update).
- [x] If this PR includes a notable change in the `math_keyboard` package, I updated the version
        according to [Dart's semantic versioning](https://stackoverflow.com/questions/66201337/how-do-dart-package-versions-work-how-should-i-version-my-flutter-plugins/66201338#66201338).
- [x] If there is new functionality in code, I added tests covering all my additions.
- [x] All required checks pass.
