### PR TITLE
Bumped Petitparser Version

### DIFF
--- a/math_keyboard/CHANGELOG.md
+++ b/math_keyboard/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.7
+
+* Updated Petitparser dependency.
+
 ## 0.1.6
 
 * Cleared Flutter 3.0.x warnings.

--- a/math_keyboard/pubspec.yaml
+++ b/math_keyboard/pubspec.yaml
@@ -2,7 +2,7 @@ name: math_keyboard
 description: >-2
   Math expression editing using an on-screen software keyboard or physical keyboard input in a
   typeset input field in Flutter.
-version: 0.1.6
+version: 0.1.7
 homepage: https://github.com/simpleclub/math_keyboard/tree/main/math_keyboard
 
 environment:
@@ -19,7 +19,7 @@ dependencies:
   holding_gesture: ^1.1.0
   intl: ^0.17.0
   math_expressions: ^2.1.0
-  petitparser: ^4.0.2
+  petitparser: ^5.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

Bumps the version of a dependency, petitparser

## Related issues & PRs

Fix to https://github.com/simpleclub/math_keyboard/issues/35

[keywords]: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

## Checklist

- [x] I have made myself familiar with the CaTeX
      [contributing guide](https://github.com/simpleclub/math_keyboard/blob/master/CONTRIBUTING.md).
- [x] I added a PR description.
- [x] I linked all related issues and PRs I could find (no links if there are none).
- [x] If this PR changes anything about the main `math_keyboard` or `example` package
      (also README etc.), I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change
      on its own is not worth an update).
- [x] All required checks pass.
