### PR TITLE
Return empty string when field is empty instead of \Box

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2021-2022 simpleclub GmbH. All rights reserved.
+Copyright 2021-2023 simpleclub GmbH. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/math_keyboard/CHANGELOG.md
+++ b/math_keyboard/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.8
+
+* Return empty string instead of \\Box when field is empty
+
 ## 0.1.7
 
 * Updated Petitparser dependency.

--- a/math_keyboard/LICENSE
+++ b/math_keyboard/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2021-2022 simpleclub GmbH. All rights reserved.
+Copyright 2021-2023 simpleclub GmbH. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/math_keyboard/lib/src/foundation/node.dart
+++ b/math_keyboard/lib/src/foundation/node.dart
@@ -95,9 +95,12 @@ class TeXNode {
   /// This includes the representation of the children of the node.
   ///
   /// Returns the TeX expression as a [String].
-  String buildTeXString({Color? cursorColor}) {
+  String buildTeXString({
+    Color? cursorColor,
+    bool placeholderWhenEmpty = true,
+  }) {
     if (children.isEmpty) {
-      return '\\Box';
+      return placeholderWhenEmpty ? '\\Box' : '';
     }
     final buffer = StringBuffer();
     for (final tex in children) {

--- a/math_keyboard/lib/src/widgets/math_field.dart
+++ b/math_keyboard/lib/src/widgets/math_field.dart
@@ -251,7 +251,9 @@ class _MathFieldState extends State<MathField> with TickerProviderStateMixin {
       });
     }
 
-    final expression = _controller.currentEditingValue();
+    final expression = _controller.currentEditingValue(
+      placeholderWhenEmpty: false,
+    );
     // We want to make sure to execute the callback after we have
     // executed all of our logic that we know has to be executed.
     // This is because the callback might throw an exception, in which
@@ -327,7 +329,9 @@ class _MathFieldState extends State<MathField> with TickerProviderStateMixin {
 
   void _submit() {
     _focusNode.unfocus();
-    widget.onSubmitted?.call(_controller.currentEditingValue());
+    widget.onSubmitted?.call(
+      _controller.currentEditingValue(placeholderWhenEmpty: false),
+    );
   }
 
   KeyEventResult _handleKey(FocusNode node, RawKeyEvent keyEvent) {
@@ -641,14 +645,16 @@ class MathFieldEditingController extends ChangeNotifier {
   late TeXNode currentNode;
 
   /// Returns the current editing value (expression), which requires temporarily
-  /// removing the cursor.
-  String currentEditingValue() {
+  /// removing the cursor. When [placeholderWhenEmpty] is true, a TeX \Box
+  /// is returned as a placeholder.
+  String currentEditingValue({bool placeholderWhenEmpty = true}) {
     currentNode.removeCursor();
     // Store the expression as a TeX string.
     final expression = root.buildTeXString(
       // By passing null as the cursor color here, we are asserting
       // that the cursor is not part of the tree in a way.
       cursorColor: null,
+      placeholderWhenEmpty: placeholderWhenEmpty,
     );
     currentNode.setCursor();
 

--- a/math_keyboard/pubspec.yaml
+++ b/math_keyboard/pubspec.yaml
@@ -2,7 +2,7 @@ name: math_keyboard
 description: >-2
   Math expression editing using an on-screen software keyboard or physical keyboard input in a
   typeset input field in Flutter.
-version: 0.1.7
+version: 0.1.8
 homepage: https://github.com/simpleclub/math_keyboard/tree/main/math_keyboard
 
 environment:


### PR DESCRIPTION
## Description

When the field is empty, `currentEditingValue` returns a TeX `\Box` as a placeholder. This was also passed to `onChanged` and `onSubmitted`, which is not expected by users. This PR adds a parameter `placeholderWhenEmpty` to fix the behavior.

## Related issues & PRs

n/a

## Checklist

- [x] I have made myself familiar with the CaTeX
      [contributing guide](https://github.com/simpleclub/math_keyboard/blob/master/CONTRIBUTING.md).
- [x] I added a PR description.
- [x] I linked all related issues and PRs I could find (no links if there are none).
- [x] If this PR changes anything about the main `math_keyboard` or `example` package
      (also README etc.), I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change
      on its own is not worth an update).
- [x] If this PR includes a notable change in the `math_keyboard` package, I updated the version
        according to [Dart's semantic versioning](https://stackoverflow.com/questions/66201337/how-do-dart-package-versions-work-how-should-i-version-my-flutter-plugins/66201338#66201338).
- [x] If there is new functionality in code, I added tests covering all my additions.
- [x] All required checks pass.
