### PR TITLE
Exposes MathKeyboard and adds some design improvements

### DIFF
--- a/math_keyboard/CHANGELOG.md
+++ b/math_keyboard/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.9
+
+* Exposes `MathKeyboards` and adds padding and hover effects to it.
+
 ## 0.1.8
 
 * Return empty string instead of \\Box when field is empty

--- a/math_keyboard/lib/math_keyboard.dart
+++ b/math_keyboard/lib/math_keyboard.dart
@@ -3,6 +3,5 @@ export 'package:math_keyboard/src/foundation/tex2math.dart';
 export 'package:math_keyboard/src/widgets/decimal_separator.dart';
 export 'package:math_keyboard/src/widgets/math_field.dart';
 export 'package:math_keyboard/src/widgets/math_form_field.dart';
-export 'package:math_keyboard/src/widgets/math_keyboard.dart'
-    show MathKeyboardType;
+export 'package:math_keyboard/src/widgets/math_keyboard.dart';
 export 'package:math_keyboard/src/widgets/view_insets.dart';

--- a/math_keyboard/lib/src/widgets/keyboard_button.dart
+++ b/math_keyboard/lib/src/widgets/keyboard_button.dart
@@ -53,7 +53,6 @@ class _KeyboardButtonState extends State<KeyboardButton>
 
   void _handleHover(bool entered) {
     _animationController.value = entered ? 0.5 : 0;
-    widget.onHold?.call();
   }
 
   void _handleTapDown(TapDownDetails details) {

--- a/math_keyboard/lib/src/widgets/keyboard_button.dart
+++ b/math_keyboard/lib/src/widgets/keyboard_button.dart
@@ -51,6 +51,11 @@ class _KeyboardButtonState extends State<KeyboardButton>
     super.dispose();
   }
 
+  void _handleHover(bool entered) {
+    _animationController.value = entered ? 0.5 : 0;
+    widget.onHold?.call();
+  }
+
   void _handleTapDown(TapDownDetails details) {
     _animationController.forward();
   }
@@ -70,44 +75,49 @@ class _KeyboardButtonState extends State<KeyboardButton>
 
   @override
   Widget build(BuildContext context) {
-    Widget result = RawGestureDetector(
-      behavior: HitTestBehavior.opaque,
-      gestures: <Type, GestureRecognizerFactory>{
-        _AlwaysWinningGestureRecognizer: GestureRecognizerFactoryWithHandlers<
-            _AlwaysWinningGestureRecognizer>(
-          () => _AlwaysWinningGestureRecognizer(),
-          (_AlwaysWinningGestureRecognizer instance) {
-            instance
-              ..onTap = widget.onTap
-              ..onTapUp = _handleTapUp
-              ..onTapDown = _handleTapDown
-              ..onTapCancel = _handleTapCancel;
-          },
-        ),
-      },
-      child: Padding(
-        padding: const EdgeInsets.all(4),
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(8),
-            color: widget.color,
-          ),
-          child: AnimatedBuilder(
-            animation: _animationController,
-            builder: (context, child) {
-              return DecoratedBox(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(8),
-                  color: Colors.white.withOpacity(
-                    Curves.easeInOut.transform(_animationController.value) / 3,
-                  ),
-                ),
-                child: Center(
-                  child: child,
-                ),
-              );
+    Widget result = MouseRegion(
+      onEnter: (_) => _handleHover(true),
+      onExit: (_) => _handleHover(false),
+      child: RawGestureDetector(
+        behavior: HitTestBehavior.opaque,
+        gestures: <Type, GestureRecognizerFactory>{
+          _AlwaysWinningGestureRecognizer: GestureRecognizerFactoryWithHandlers<
+              _AlwaysWinningGestureRecognizer>(
+            () => _AlwaysWinningGestureRecognizer(),
+            (_AlwaysWinningGestureRecognizer instance) {
+              instance
+                ..onTap = widget.onTap
+                ..onTapUp = _handleTapUp
+                ..onTapDown = _handleTapDown
+                ..onTapCancel = _handleTapCancel;
             },
-            child: widget.child,
+          ),
+        },
+        child: Padding(
+          padding: const EdgeInsets.all(4),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              color: widget.color,
+            ),
+            child: AnimatedBuilder(
+              animation: _animationController,
+              builder: (context, child) {
+                return DecoratedBox(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(8),
+                    color: Colors.white.withOpacity(
+                      Curves.easeInOut.transform(_animationController.value) /
+                          3,
+                    ),
+                  ),
+                  child: Center(
+                    child: child,
+                  ),
+                );
+              },
+              child: widget.child,
+            ),
           ),
         ),
       ),

--- a/math_keyboard/lib/src/widgets/math_field.dart
+++ b/math_keyboard/lib/src/widgets/math_field.dart
@@ -26,6 +26,7 @@ class MathField extends StatefulWidget {
     this.decoration = const InputDecoration(),
     this.onChanged,
     this.onSubmitted,
+    this.opensKeyboard = true,
   }) : super(key: key);
 
   /// The controller for the math field.
@@ -106,6 +107,14 @@ class MathField extends StatefulWidget {
   ///
   /// Can be `null`.
   final ValueChanged<String>? onSubmitted;
+
+  /// Whether the field should open a keyboard on focus by itself or not.
+  ///
+  /// Set this to false if you want to provide input via an external source by
+  /// using [controller].
+  ///
+  /// Defaults to `true`.
+  final bool opensKeyboard;
 
   @override
   _MathFieldState createState() => _MathFieldState();
@@ -302,6 +311,8 @@ class _MathFieldState extends State<MathField> with TickerProviderStateMixin {
   }
 
   void _openKeyboard(BuildContext context) {
+    if (!widget.opensKeyboard) return;
+
     _overlayEntry?.remove();
     _overlayEntry = OverlayEntry(
       builder: (context) {

--- a/math_keyboard/lib/src/widgets/math_field.dart
+++ b/math_keyboard/lib/src/widgets/math_field.dart
@@ -335,7 +335,7 @@ class _MathFieldState extends State<MathField> with TickerProviderStateMixin {
       },
     );
 
-    Overlay.of(context)!.insert(_overlayEntry!);
+    Overlay.of(context).insert(_overlayEntry!);
   }
 
   void _submit() {
@@ -560,7 +560,7 @@ class _FieldPreview extends StatelessWidget {
 
   // Adapted from InputDecorator._getInlineStyle.
   TextStyle _getHintStyle(ThemeData themeData) {
-    return themeData.textTheme.subtitle1!
+    return themeData.textTheme.titleMedium!
         .copyWith(
             color: decoration.enabled
                 ? themeData.hintColor

--- a/math_keyboard/lib/src/widgets/math_keyboard.dart
+++ b/math_keyboard/lib/src/widgets/math_keyboard.dart
@@ -34,6 +34,11 @@ class MathKeyboard extends StatelessWidget {
     this.onSubmit,
     this.insetsState,
     this.slideAnimation,
+    this.padding = const EdgeInsets.only(
+      bottom: 4,
+      left: 4,
+      right: 4,
+    ),
   }) : super(key: key);
 
   /// The controller for editing the math field.
@@ -61,6 +66,11 @@ class MathKeyboard extends StatelessWidget {
   ///
   /// Can be `null`.
   final VoidCallback? onSubmit;
+
+  /// Insets of the keyboard.
+  ///
+  /// Defaults to `const EdgeInsets.only(bottom: 4, left: 4, right: 4),`.
+  final EdgeInsets padding;
 
   @override
   Widget build(BuildContext context) {
@@ -91,11 +101,7 @@ class MathKeyboard extends StatelessWidget {
                     slideAnimation:
                         slideAnimation == null ? null : curvedSlideAnimation,
                     child: Padding(
-                      padding: const EdgeInsets.only(
-                        bottom: 4,
-                        left: 4,
-                        right: 4,
-                      ),
+                      padding: padding,
                       child: Center(
                         child: ConstrainedBox(
                           constraints: const BoxConstraints(

--- a/math_keyboard/pubspec.yaml
+++ b/math_keyboard/pubspec.yaml
@@ -2,7 +2,7 @@ name: math_keyboard
 description: >-2
   Math expression editing using an on-screen software keyboard or physical keyboard input in a
   typeset input field in Flutter.
-version: 0.1.10
+version: 0.1.9
 homepage: https://github.com/simpleclub/math_keyboard/tree/main/math_keyboard
 
 environment:

--- a/math_keyboard/pubspec.yaml
+++ b/math_keyboard/pubspec.yaml
@@ -2,7 +2,7 @@ name: math_keyboard
 description: >-2
   Math expression editing using an on-screen software keyboard or physical keyboard input in a
   typeset input field in Flutter.
-version: 0.1.9
+version: 0.1.10
 homepage: https://github.com/simpleclub/math_keyboard/tree/main/math_keyboard
 
 environment:

--- a/math_keyboard_demo/lib/widgets/page_view.dart
+++ b/math_keyboard_demo/lib/widgets/page_view.dart
@@ -247,7 +247,7 @@ class _PrimaryPageState extends State<_PrimaryPage> {
           ),
           child: Text(
             'Try it now!',
-            style: Theme.of(context).textTheme.headline5!.copyWith(
+            style: Theme.of(context).textTheme.headlineSmall!.copyWith(
                   fontStyle: FontStyle.italic,
                 ),
             textAlign: TextAlign.center,
@@ -311,7 +311,7 @@ class _InputDecorationPage extends StatelessWidget {
           ),
           child: Text(
             'Completely customizable with InputDecoration!',
-            style: Theme.of(context).textTheme.headline5!.copyWith(
+            style: Theme.of(context).textTheme.headlineSmall!.copyWith(
                   fontStyle: FontStyle.italic,
                 ),
             textAlign: TextAlign.center,
@@ -422,7 +422,7 @@ class _ControllerPageState extends State<_ControllerPage> {
           ),
           child: Text(
             'Fully controllable using custom controllers!',
-            style: Theme.of(context).textTheme.headline5!.copyWith(
+            style: Theme.of(context).textTheme.headlineSmall!.copyWith(
                   fontStyle: FontStyle.italic,
                 ),
             textAlign: TextAlign.center,
@@ -581,7 +581,7 @@ class _AutofocusPage extends StatelessWidget {
           ),
           child: Text(
             'With autofocus support!',
-            style: Theme.of(context).textTheme.headline5!.copyWith(
+            style: Theme.of(context).textTheme.headlineSmall!.copyWith(
                   fontStyle: FontStyle.italic,
                 ),
             textAlign: TextAlign.center,
@@ -646,7 +646,7 @@ class _FocusTreePageState extends State<_FocusTreePage> {
           ),
           child: Text(
             'And focus tree integration!',
-            style: Theme.of(context).textTheme.headline5!.copyWith(
+            style: Theme.of(context).textTheme.headlineSmall!.copyWith(
                   fontStyle: FontStyle.italic,
                 ),
             textAlign: TextAlign.center,
@@ -788,7 +788,7 @@ class _DecimalSeparatorPageState extends State<_DecimalSeparatorPage> {
           ),
           child: Text(
             'Adaptive decimal separators!',
-            style: Theme.of(context).textTheme.headline5!.copyWith(
+            style: Theme.of(context).textTheme.headlineSmall!.copyWith(
                   fontStyle: FontStyle.italic,
                 ),
             textAlign: TextAlign.center,
@@ -900,7 +900,7 @@ class _MathExpressionsPageState extends State<_MathExpressionsPage> {
           ),
           child: Text(
             'Math expression support!',
-            style: Theme.of(context).textTheme.headline5!.copyWith(
+            style: Theme.of(context).textTheme.headlineSmall!.copyWith(
                   fontStyle: FontStyle.italic,
                 ),
             textAlign: TextAlign.center,
@@ -1024,7 +1024,7 @@ class _FormFieldPage extends StatelessWidget {
                 ),
                 child: Text(
                   'Last but not least: form fields!',
-                  style: Theme.of(context).textTheme.headline5!.copyWith(
+                  style: Theme.of(context).textTheme.headlineSmall!.copyWith(
                         fontStyle: FontStyle.italic,
                       ),
                   textAlign: TextAlign.center,
@@ -1068,7 +1068,7 @@ class _FormFieldPage extends StatelessWidget {
                 padding: const EdgeInsets.only(top: 16),
                 child: TextButton(
                   onPressed: () {
-                    final result = Form.of(context)!.validate();
+                    final result = Form.of(context).validate();
 
                     if (result == true) {
                       ScaffoldMessenger.of(context).showSnackBar(SnackBar(

--- a/math_keyboard_demo/lib/widgets/scaffold.dart
+++ b/math_keyboard_demo/lib/widgets/scaffold.dart
@@ -80,10 +80,12 @@ class DemoScaffold extends StatelessWidget {
                           },
                           child: Text(
                             header,
-                            style:
-                                Theme.of(context).textTheme.headline5?.copyWith(
-                                      fontWeight: FontWeight.w500,
-                                    ),
+                            style: Theme.of(context)
+                                .textTheme
+                                .headlineSmall
+                                ?.copyWith(
+                                  fontWeight: FontWeight.w500,
+                                ),
                             textAlign: TextAlign.center,
                           ),
                         ),
@@ -135,7 +137,7 @@ class DemoScaffold extends StatelessWidget {
                                   ],
                                   style: Theme.of(context)
                                       .textTheme
-                                      .headline5
+                                      .headlineSmall
                                       ?.copyWith(
                                         fontSize: 28,
                                       ),


### PR DESCRIPTION
## Description

Exposes `MathKeyboard` so it can be used independently from `MathField`. Also adds a hover effect on `MathKeyboard` for better web support and some padding.

## Checklist

*Remove `If [...]` items that do not apply to your PR.*

- [x] I have made myself familiar with the CaTeX
      [contributing guide](https://github.com/simpleclub/math_keyboard/blob/master/CONTRIBUTING.md).
- [x] I added a PR description.
- [x] I linked all related issues and PRs I could find (no links if there are none).
- [x] If this PR changes anything about the main `math_keyboard` or `example` package
      (also README etc.), I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change
      on its own is not worth an update).
- [x] If this PR includes a notable change in the `math_keyboard` package, I updated the version
        according to [Dart's semantic versioning](https://stackoverflow.com/questions/66201337/how-do-dart-package-versions-work-how-should-i-version-my-flutter-plugins/66201338#66201338).
- [ ] If there is new functionality in code, I added tests covering all my additions.
- [x] All required checks pass.
