### PR TITLE
Bump flutter_math_fork and intl

### DIFF
--- a/math_keyboard/CHANGELOG.md
+++ b/math_keyboard/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+* Bumped `flutter_math_fork` and `intl`.
+
 ## 0.1.9
 
 * Exposes `MathKeyboards` and adds padding and hover effects to it.

--- a/math_keyboard/lib/src/widgets/view_insets.dart
+++ b/math_keyboard/lib/src/widgets/view_insets.dart
@@ -211,11 +211,11 @@ class MathKeyboardViewInsetsQuery extends InheritedWidget {
   static bool keyboardShowingIn(BuildContext context) {
     final maxInset = max(
       of(context).bottomInset,
-      WidgetsBinding.instance.window.viewInsets.bottom /
+      View.of(context).viewInsets.bottom /
           // Note that we obviously do not care about the pixel ratio for our
           // > 0 comparison, however, I do want to prevent any future mistake,
           // where someone forgets the pixel ratio on the window.
-          WidgetsBinding.instance.window.devicePixelRatio,
+          View.of(context).devicePixelRatio,
     );
 
     return maxInset > 0;

--- a/math_keyboard/pubspec.yaml
+++ b/math_keyboard/pubspec.yaml
@@ -2,11 +2,11 @@ name: math_keyboard
 description: >-2
   Math expression editing using an on-screen software keyboard or physical keyboard input in a
   typeset input field in Flutter.
-version: 0.1.9
+version: 0.2.0
 homepage: https://github.com/simpleclub/math_keyboard/tree/main/math_keyboard
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
   flutter: '>=2.0.0'
 
 dependencies:
@@ -15,9 +15,9 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  flutter_math_fork: ^0.6.3+1
+  flutter_math_fork: ^0.7.1
   holding_gesture: ^1.1.0
-  intl: ^0.17.0
+  intl: ^0.18.0
   math_expressions: ^2.1.0
   petitparser: ^5.0.0
 

--- a/math_keyboard_demo/pubspec.yaml
+++ b/math_keyboard_demo/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  flutter_svg: ^1.0.0
+  flutter_svg: ^2.0.5
 
   math_keyboard:
     path: ../math_keyboard


### PR DESCRIPTION
## Description

Bumps `flutter_math_fork` and `intl` to be compatible with flutter `3.10.0`.

## Related issues & PRs

https://github.com/simpleclub/math_keyboard/issues/51

## Checklist

- [x] I have made myself familiar with the CaTeX
      [contributing guide](https://github.com/simpleclub/math_keyboard/blob/master/CONTRIBUTING.md).
- [x] I added a PR description.
- [x] I linked all related issues and PRs I could find (no links if there are none).
- [x] If this PR changes anything about the main `math_keyboard` or `example` package
      (also README etc.), I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change
      on its own is not worth an update).
- [x] If this PR includes a notable change in the `math_keyboard` package, I updated the version
        according to [Dart's semantic versioning](https://stackoverflow.com/questions/66201337/how-do-dart-package-versions-work-how-should-i-version-my-flutter-plugins/66201338#66201338).
- [x] If there is new functionality in code, I added tests covering all my additions.
- [x] All required checks pass.
