### PR TITLE
feat: Adds support for custom keyboard pages and other customizations

### DIFF
--- a/math_keyboard/CHANGELOG.md
+++ b/math_keyboard/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.0
+
+* Adds support for custom keyboard pages using the new `customPages` attribute that takes a list of `CustomButtonPage`s.
+* BREAKING: `bool secondPage` has been replaced with `int page` in `MathFieldEditingController`.
+* Adds a `fontSize` attribute to `MathKeyboard` and a `keyboardButtonFontSize` attribute to `MathField`.
+* Adds a `heightFactor` attribute to `KeyboardButtonConfig`
+
 ## 0.2.1
 
 * Added Android support to the demo project.

--- a/math_keyboard/lib/math_keyboard.dart
+++ b/math_keyboard/lib/math_keyboard.dart
@@ -1,5 +1,8 @@
 export 'package:math_keyboard/src/foundation/math2tex.dart';
 export 'package:math_keyboard/src/foundation/tex2math.dart';
+export 'package:math_keyboard/src/foundation/keyboard_button.dart';
+export 'package:math_keyboard/src/foundation/node.dart';
+export 'package:math_keyboard/src/custom_button_pages/custom_button_page.dart';
 export 'package:math_keyboard/src/widgets/decimal_separator.dart';
 export 'package:math_keyboard/src/widgets/math_field.dart';
 export 'package:math_keyboard/src/widgets/math_form_field.dart';

--- a/math_keyboard/lib/src/custom_button_pages/custom_button_page.dart
+++ b/math_keyboard/lib/src/custom_button_pages/custom_button_page.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:math_keyboard/src/foundation/keyboard_button.dart';
+
+/// Defines the layout and options for a page of buttons on the keyboard.
+class CustomButtonPage {
+  /// Defines the layout of the buttons on the page.
+  final List<List<KeyboardButtonConfig>> buttonLayout;
+
+  /// An optional label to help users identify this page.
+  final String? label;
+
+  /// An optional icon to help users identify this page. If both an icon and
+  /// label are provided, the icon will be preferred.
+  final IconData? icon;
+
+  /// Defines a custom button page, optionally including a label or icon
+  /// that represent the contents of the page.
+  const CustomButtonPage({
+    required this.buttonLayout,
+    this.label,
+    this.icon,
+  });
+}

--- a/math_keyboard/lib/src/foundation/keyboard_button.dart
+++ b/math_keyboard/lib/src/foundation/keyboard_button.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/services.dart';
+import 'package:math_keyboard/src/custom_button_pages/custom_button_page.dart';
+import 'package:math_keyboard/src/custom_key_icons/custom_key_icons.dart';
 import 'package:math_keyboard/src/foundation/node.dart';
 
 /// Class representing a button configuration.
@@ -6,11 +8,18 @@ abstract class KeyboardButtonConfig {
   /// Constructs a [KeyboardButtonConfig].
   const KeyboardButtonConfig({
     this.flex,
+    this.heightFactor,
     this.keyboardCharacters = const [],
   });
 
   /// Optional flex.
   final int? flex;
+
+  /// Optional height factor. If null, defaults to 1. For every row, the button
+  /// with the largest height factor is used to calculate the height of the row.
+  /// [heightFactor] values less than this maximum will be ignored and the
+  /// button will expand to the full height of the row.
+  final double? heightFactor;
 
   /// The list of [RawKeyEvent.character] that should trigger this keyboard
   /// button on a physical keyboard.
@@ -35,9 +44,11 @@ class BasicKeyboardButtonConfig extends KeyboardButtonConfig {
     this.highlighted = false,
     List<String> keyboardCharacters = const [],
     int? flex,
+    double? heightFactor,
   }) : super(
           flex: flex,
           keyboardCharacters: keyboardCharacters,
+          heightFactor: heightFactor,
         );
 
   /// The label of the button.
@@ -113,188 +124,197 @@ const _subtractButton = BasicKeyboardButtonConfig(
 );
 
 /// Keyboard showing extended functionality.
-final functionKeyboard = [
-  [
-    const BasicKeyboardButtonConfig(
-      label: r'\frac{\Box}{\Box}',
-      value: r'\frac',
-      args: [TeXArg.braces, TeXArg.braces],
-      asTex: true,
-    ),
-    const BasicKeyboardButtonConfig(
-      label: r'\Box^2',
-      value: '^2',
-      args: [TeXArg.braces],
-      asTex: true,
-    ),
-    const BasicKeyboardButtonConfig(
-      label: r'\Box^{\Box}',
-      value: '^',
-      args: [TeXArg.braces],
-      asTex: true,
-      keyboardCharacters: [
-        '^',
-        // This is a workaround for keyboard layout that use ^ as a toggle key.
-        // In that case, "Dead" is reported as the character (e.g. for German
-        // keyboards).
-        'Dead',
-      ],
-    ),
-    const BasicKeyboardButtonConfig(
-      label: r'\sin',
-      value: r'\sin(',
-      asTex: true,
-      keyboardCharacters: ['s'],
-    ),
-    const BasicKeyboardButtonConfig(
-      label: r'\sin^{-1}',
-      value: r'\sin^{-1}(',
-      asTex: true,
-    ),
+final functionKeyboard = CustomButtonPage(
+  icon: CustomKeyIcons.key_symbols,
+  buttonLayout: [
+    [
+      const BasicKeyboardButtonConfig(
+        label: r'\frac{\Box}{\Box}',
+        value: r'\frac',
+        args: [TeXArg.braces, TeXArg.braces],
+        asTex: true,
+      ),
+      const BasicKeyboardButtonConfig(
+        label: r'\Box^2',
+        value: '^2',
+        args: [TeXArg.braces],
+        asTex: true,
+      ),
+      const BasicKeyboardButtonConfig(
+        label: r'\Box^{\Box}',
+        value: '^',
+        args: [TeXArg.braces],
+        asTex: true,
+        keyboardCharacters: [
+          '^',
+          // This is a workaround for keyboard layout that use ^ as a toggle key.
+          // In that case, "Dead" is reported as the character (e.g. for German
+          // keyboards).
+          'Dead',
+        ],
+      ),
+      const BasicKeyboardButtonConfig(
+        label: r'\sin',
+        value: r'\sin(',
+        asTex: true,
+        keyboardCharacters: ['s'],
+      ),
+      const BasicKeyboardButtonConfig(
+        label: r'\sin^{-1}',
+        value: r'\sin^{-1}(',
+        asTex: true,
+      ),
+    ],
+    [
+      const BasicKeyboardButtonConfig(
+        label: r'\sqrt{\Box}',
+        value: r'\sqrt',
+        args: [TeXArg.braces],
+        asTex: true,
+        keyboardCharacters: ['r'],
+      ),
+      const BasicKeyboardButtonConfig(
+        label: r'\sqrt[\Box]{\Box}',
+        value: r'\sqrt',
+        args: [TeXArg.brackets, TeXArg.braces],
+        asTex: true,
+      ),
+      const BasicKeyboardButtonConfig(
+        label: r'\cos',
+        value: r'\cos(',
+        asTex: true,
+        keyboardCharacters: ['c'],
+      ),
+      const BasicKeyboardButtonConfig(
+        label: r'\cos^{-1}',
+        value: r'\cos^{-1}(',
+        asTex: true,
+      ),
+    ],
+    [
+      const BasicKeyboardButtonConfig(
+        label: r'\log_{\Box}(\Box)',
+        value: r'\log_',
+        asTex: true,
+        args: [TeXArg.braces, TeXArg.parentheses],
+      ),
+      const BasicKeyboardButtonConfig(
+        label: r'\ln(\Box)',
+        value: r'\ln(',
+        asTex: true,
+        keyboardCharacters: ['l'],
+      ),
+      const BasicKeyboardButtonConfig(
+        label: r'\tan',
+        value: r'\tan(',
+        asTex: true,
+        keyboardCharacters: ['t'],
+      ),
+      const BasicKeyboardButtonConfig(
+        label: r'\tan^{-1}',
+        value: r'\tan^{-1}(',
+        asTex: true,
+      ),
+    ],
+    [
+      const PageButtonConfig(flex: 3),
+      const BasicKeyboardButtonConfig(
+        label: '(',
+        value: '(',
+        highlighted: true,
+        keyboardCharacters: ['('],
+      ),
+      const BasicKeyboardButtonConfig(
+        label: ')',
+        value: ')',
+        highlighted: true,
+        keyboardCharacters: [')'],
+      ),
+      PreviousButtonConfig(),
+      NextButtonConfig(),
+      DeleteButtonConfig(),
+    ],
   ],
-  [
-    const BasicKeyboardButtonConfig(
-      label: r'\sqrt{\Box}',
-      value: r'\sqrt',
-      args: [TeXArg.braces],
-      asTex: true,
-      keyboardCharacters: ['r'],
-    ),
-    const BasicKeyboardButtonConfig(
-      label: r'\sqrt[\Box]{\Box}',
-      value: r'\sqrt',
-      args: [TeXArg.brackets, TeXArg.braces],
-      asTex: true,
-    ),
-    const BasicKeyboardButtonConfig(
-      label: r'\cos',
-      value: r'\cos(',
-      asTex: true,
-      keyboardCharacters: ['c'],
-    ),
-    const BasicKeyboardButtonConfig(
-      label: r'\cos^{-1}',
-      value: r'\cos^{-1}(',
-      asTex: true,
-    ),
-  ],
-  [
-    const BasicKeyboardButtonConfig(
-      label: r'\log_{\Box}(\Box)',
-      value: r'\log_',
-      asTex: true,
-      args: [TeXArg.braces, TeXArg.parentheses],
-    ),
-    const BasicKeyboardButtonConfig(
-      label: r'\ln(\Box)',
-      value: r'\ln(',
-      asTex: true,
-      keyboardCharacters: ['l'],
-    ),
-    const BasicKeyboardButtonConfig(
-      label: r'\tan',
-      value: r'\tan(',
-      asTex: true,
-      keyboardCharacters: ['t'],
-    ),
-    const BasicKeyboardButtonConfig(
-      label: r'\tan^{-1}',
-      value: r'\tan^{-1}(',
-      asTex: true,
-    ),
-  ],
-  [
-    const PageButtonConfig(flex: 3),
-    const BasicKeyboardButtonConfig(
-      label: '(',
-      value: '(',
-      highlighted: true,
-      keyboardCharacters: ['('],
-    ),
-    const BasicKeyboardButtonConfig(
-      label: ')',
-      value: ')',
-      highlighted: true,
-      keyboardCharacters: [')'],
-    ),
-    PreviousButtonConfig(),
-    NextButtonConfig(),
-    DeleteButtonConfig(),
-  ],
-];
+);
 
 /// Standard keyboard for math expression input.
-final standardKeyboard = [
-  [
-    _digitButtons[7],
-    _digitButtons[8],
-    _digitButtons[9],
-    const BasicKeyboardButtonConfig(
-      label: '×',
-      value: r'\cdot',
-      keyboardCharacters: ['*'],
-      highlighted: true,
-    ),
-    const BasicKeyboardButtonConfig(
-      label: '÷',
-      value: r'\frac',
-      keyboardCharacters: ['/'],
-      args: [TeXArg.braces, TeXArg.braces],
-      highlighted: true,
-    ),
+final standardKeyboard = CustomButtonPage(
+  label: '123',
+  buttonLayout: [
+    [
+      _digitButtons[7],
+      _digitButtons[8],
+      _digitButtons[9],
+      const BasicKeyboardButtonConfig(
+        label: '×',
+        value: r'\cdot',
+        keyboardCharacters: ['*'],
+        highlighted: true,
+      ),
+      const BasicKeyboardButtonConfig(
+        label: '÷',
+        value: r'\frac',
+        keyboardCharacters: ['/'],
+        args: [TeXArg.braces, TeXArg.braces],
+        highlighted: true,
+      ),
+    ],
+    [
+      _digitButtons[4],
+      _digitButtons[5],
+      _digitButtons[6],
+      const BasicKeyboardButtonConfig(
+        label: '+',
+        value: '+',
+        keyboardCharacters: ['+'],
+        highlighted: true,
+      ),
+      _subtractButton,
+    ],
+    [
+      _digitButtons[1],
+      _digitButtons[2],
+      _digitButtons[3],
+      _decimalButton,
+      DeleteButtonConfig(),
+    ],
+    [
+      const PageButtonConfig(),
+      _digitButtons[0],
+      PreviousButtonConfig(),
+      NextButtonConfig(),
+      SubmitButtonConfig(),
+    ],
   ],
-  [
-    _digitButtons[4],
-    _digitButtons[5],
-    _digitButtons[6],
-    const BasicKeyboardButtonConfig(
-      label: '+',
-      value: '+',
-      keyboardCharacters: ['+'],
-      highlighted: true,
-    ),
-    _subtractButton,
-  ],
-  [
-    _digitButtons[1],
-    _digitButtons[2],
-    _digitButtons[3],
-    _decimalButton,
-    DeleteButtonConfig(),
-  ],
-  [
-    const PageButtonConfig(),
-    _digitButtons[0],
-    PreviousButtonConfig(),
-    NextButtonConfig(),
-    SubmitButtonConfig(),
-  ],
-];
+);
 
 /// Keyboard getting shown for number input only.
-final numberKeyboard = [
-  [
-    _digitButtons[7],
-    _digitButtons[8],
-    _digitButtons[9],
-    _subtractButton,
+final numberKeyboard = CustomButtonPage(
+  label: '123',
+  buttonLayout: [
+    [
+      _digitButtons[7],
+      _digitButtons[8],
+      _digitButtons[9],
+      _subtractButton,
+    ],
+    [
+      _digitButtons[4],
+      _digitButtons[5],
+      _digitButtons[6],
+      _decimalButton,
+    ],
+    [
+      _digitButtons[1],
+      _digitButtons[2],
+      _digitButtons[3],
+      DeleteButtonConfig(),
+    ],
+    [
+      PreviousButtonConfig(),
+      _digitButtons[0],
+      NextButtonConfig(),
+      SubmitButtonConfig(),
+    ],
   ],
-  [
-    _digitButtons[4],
-    _digitButtons[5],
-    _digitButtons[6],
-    _decimalButton,
-  ],
-  [
-    _digitButtons[1],
-    _digitButtons[2],
-    _digitButtons[3],
-    DeleteButtonConfig(),
-  ],
-  [
-    PreviousButtonConfig(),
-    _digitButtons[0],
-    NextButtonConfig(),
-    SubmitButtonConfig(),
-  ],
-];
+);

--- a/math_keyboard/lib/src/widgets/math_form_field.dart
+++ b/math_keyboard/lib/src/widgets/math_form_field.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:math_keyboard/src/custom_button_pages/custom_button_page.dart';
 import 'package:math_keyboard/src/widgets/math_field.dart';
 import 'package:math_keyboard/src/widgets/math_keyboard.dart';
 
@@ -32,6 +33,7 @@ class MathFormField extends FormField<String> {
     ValueChanged<String>? onFieldSubmitted,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     FormFieldValidator<String>? validator,
+    List<CustomButtonPage> customPages = const [],
   }) : super(
           key: key,
           initialValue:
@@ -57,6 +59,7 @@ class MathFormField extends FormField<String> {
               autofocus: autofocus,
               onChanged: onChangedHandler,
               onSubmitted: onFieldSubmitted,
+              customPages: customPages,
             );
           },
         );

--- a/math_keyboard/pubspec.yaml
+++ b/math_keyboard/pubspec.yaml
@@ -2,7 +2,7 @@ name: math_keyboard
 description: >-2
   Math expression editing using an on-screen software keyboard or physical keyboard input in a
   typeset input field in Flutter.
-version: 0.2.1
+version: 0.3.0
 homepage: https://github.com/simpleclub/math_keyboard/tree/main/math_keyboard
 
 environment:

--- a/math_keyboard/test/README.md
+++ b/math_keyboard/test/README.md
@@ -10,7 +10,7 @@ On top of that, it should be noted that we have **internal test cases**
 we need it to when integrating (on the unit level) with proprietary systems.
 This is to say that if you are missing a test case (you are wondering why it
 is not covered), it might be that we have an internal test case that is not
-included in this repo that makes us feel like that particalur case is covered.
+included in this repo that makes us feel like that particular case is covered.
 Do feel free, however, to contribute any missing test cases in this repo as well
 as they will always be more focused this way :)
 

--- a/math_keyboard/test/widgets/math_keyboard_test.dart
+++ b/math_keyboard/test/widgets/math_keyboard_test.dart
@@ -1,0 +1,354 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:math_keyboard/math_keyboard.dart';
+import 'package:math_keyboard/src/custom_key_icons/custom_key_icons.dart';
+
+class TestWrapper extends StatelessWidget {
+  const TestWrapper({
+    Key? key,
+    required this.child,
+  }) : super(key: key);
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: child,
+    );
+  }
+}
+
+void main() {
+  testWidgets(
+    'Control test to ensure the default keyboard is shown on the page',
+    (tester) async {
+      final controller = MathFieldEditingController();
+
+      await tester.pumpWidget(TestWrapper(
+        child: MathKeyboard(
+          controller: controller,
+        ),
+      ));
+      expect(find.byType(MathKeyboard), findsOneWidget);
+
+      controller.dispose();
+    },
+  );
+
+  testWidgets(
+    'Test that updating the keyboard page using controller works correctly',
+    (tester) async {
+      final controller = MathFieldEditingController();
+      final tree = TestWrapper(
+        child: MathKeyboard(
+          controller: controller,
+          // The default width of a the test widget view is too small to
+          // render the expressions keyboard without overflow.
+          // We'll decrease the font size of the keyboard text in order to test
+          // without getting overflow errors.
+          fontSize: 16,
+        ),
+      );
+
+      await tester.pumpWidget(tree);
+
+      // Check that the toggle page button shows the symbol for the next page
+      expect(find.byIcon(CustomKeyIcons.key_symbols), findsOneWidget);
+      expect(find.text('5'), findsOneWidget);
+      expect(find.text('123'), findsNothing);
+
+      controller.togglePage();
+      await tester.pumpWidget(tree);
+
+      // Check again that keyboard shows the correct symbol for the next page
+      expect(find.byIcon(CustomKeyIcons.key_symbols), findsNothing);
+      expect(find.text('5'), findsNothing);
+      expect(find.text('123'), findsOneWidget);
+
+      controller.togglePage();
+      await tester.pumpWidget(tree);
+
+      // Check that we've returned again to the first page
+      expect(find.byIcon(CustomKeyIcons.key_symbols), findsOneWidget);
+      expect(find.text('5'), findsOneWidget);
+      expect(find.text('123'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'Test that updating the keyboard page using the button works correctly',
+    (tester) async {
+      final controller = MathFieldEditingController();
+      final tree = TestWrapper(
+        child: MathKeyboard(
+          controller: controller,
+          // The default width of a the test widget view is too small to
+          // render the expressions keyboard without overflow.
+          // We'll decrease the font size of the keyboard text in order to test
+          // without getting overflow errors.
+          fontSize: 16,
+        ),
+      );
+
+      await tester.pumpWidget(tree);
+
+      // Check that we are on the first page
+      expect(controller.page, equals(0));
+      expect(find.text('5'), findsOneWidget);
+
+      await tester.tap(find.byIcon(CustomKeyIcons.key_symbols));
+      await tester.pumpWidget(tree);
+
+      // Check that we've moved to the second page
+      expect(controller.page, equals(1));
+      expect(find.text('5'), findsNothing);
+
+      await tester.tap(find.text('123'));
+      await tester.pumpWidget(tree);
+
+      // Check that we've moved back to the first page (and that pages have looped correctly)
+      expect(controller.page, equals(2));
+      expect(find.byIcon(CustomKeyIcons.key_symbols), findsOneWidget);
+      expect(find.text('5'), findsOneWidget);
+      expect(find.text('123'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'Test that updating the keyboard page on a numbers-only keyboard has no effect',
+    (tester) async {
+      final controller = MathFieldEditingController();
+      final tree = TestWrapper(
+        child: MathKeyboard(
+          controller: controller,
+          type: MathKeyboardType.numberOnly,
+        ),
+      );
+
+      await tester.pumpWidget(tree);
+
+      // Check that we are on the first page
+      expect(controller.page, equals(0));
+      expect(find.text('5'), findsOneWidget);
+
+      controller.togglePage();
+      await tester.pumpWidget(tree);
+
+      // Check that we've incremented our page, but that we're actually still
+      // on the number-only page.
+      expect(controller.page, equals(1));
+      expect(find.text('5'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'Test that displaying a custom keyboard page is possible',
+    (tester) async {
+      final controller = MathFieldEditingController();
+      final tree = TestWrapper(
+        child: MathKeyboard(
+          controller: controller,
+          type: MathKeyboardType.custom,
+          customPages: [
+            CustomButtonPage(buttonLayout: [
+              [
+                BasicKeyboardButtonConfig(
+                  label: 'TEST',
+                  value: '',
+                ),
+              ]
+            ]),
+          ],
+        ),
+      );
+
+      await tester.pumpWidget(tree);
+
+      // Check that the custom button is visible
+      expect(find.text('TEST'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'Test that we can toggle between multiple custom keyboard pages',
+    (tester) async {
+      final controller = MathFieldEditingController();
+      final tree = TestWrapper(
+        child: MathKeyboard(
+          controller: controller,
+          type: MathKeyboardType.custom,
+          customPages: [
+            CustomButtonPage(buttonLayout: [
+              [
+                BasicKeyboardButtonConfig(
+                  label: 'TEST 0',
+                  value: '',
+                ),
+              ]
+            ]),
+            CustomButtonPage(buttonLayout: [
+              [
+                BasicKeyboardButtonConfig(
+                  label: 'TEST 1',
+                  value: '',
+                ),
+              ]
+            ]),
+            CustomButtonPage(buttonLayout: [
+              [
+                BasicKeyboardButtonConfig(
+                  label: 'TEST 2',
+                  value: '',
+                ),
+              ]
+            ]),
+          ],
+        ),
+      );
+
+      await tester.pumpWidget(tree);
+
+      // Check that the first custom page is visible
+      expect(find.text('TEST 0'), findsOneWidget);
+      // Check that no other pages are visible
+      expect(find.text('TEST 1'), findsNothing);
+      expect(find.text('TEST 2'), findsNothing);
+
+      controller.togglePage();
+      await tester.pumpWidget(tree);
+
+      // Check that the second custom page is visible
+      expect(find.text('TEST 1'), findsOneWidget);
+      // Check that the first page is no longer visible
+      expect(find.text('TEST 0'), findsNothing);
+      // Check that the last page is still not visible
+      expect(find.text('TEST 2'), findsNothing);
+
+      controller.togglePage();
+      await tester.pumpWidget(tree);
+
+      // Check that the last custom page is visible
+      expect(find.text('TEST 2'), findsOneWidget);
+      // Check that the first page is still not visible
+      expect(find.text('TEST 0'), findsNothing);
+      // Check that the middle page is no longer visible
+      expect(find.text('TEST 1'), findsNothing);
+
+      controller.togglePage();
+      await tester.pumpWidget(tree);
+
+      // Check that we've wrapped around and the first custom page is visible
+      expect(find.text('TEST 0'), findsOneWidget);
+      // Check that the middle page is still not visible
+      expect(find.text('TEST 1'), findsNothing);
+      // Check that the last page is no longer visible
+      expect(find.text('TEST 2'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'Test that we can toggle multiple custom keyboard pages using a button',
+    (tester) async {
+      final controller = MathFieldEditingController();
+      final tree = TestWrapper(
+        child: MathKeyboard(
+          controller: controller,
+          type: MathKeyboardType.custom,
+          customPages: [
+            CustomButtonPage(
+              label: 'Page 0',
+              buttonLayout: [
+                [
+                  BasicKeyboardButtonConfig(
+                    label: 'TEST 0',
+                    value: '',
+                  ),
+                  PageButtonConfig(),
+                ]
+              ],
+            ),
+            CustomButtonPage(
+              label: 'Page 1',
+              buttonLayout: [
+                [
+                  BasicKeyboardButtonConfig(
+                    label: 'TEST 1',
+                    value: '',
+                  ),
+                  PageButtonConfig(),
+                ]
+              ],
+            ),
+            CustomButtonPage(
+              label: 'Page 2',
+              buttonLayout: [
+                [
+                  BasicKeyboardButtonConfig(
+                    label: 'TEST 2',
+                    value: '',
+                  ),
+                  PageButtonConfig(),
+                ]
+              ],
+            ),
+          ],
+        ),
+      );
+
+      await tester.pumpWidget(tree);
+
+      // Check that the first custom page is visible
+      expect(find.text('TEST 0'), findsOneWidget);
+      // Check that no other pages are visible
+      expect(find.text('TEST 1'), findsNothing);
+      expect(find.text('TEST 2'), findsNothing);
+      // Check that the correct label for the next page is visible
+      expect(find.text('Page 0'), findsNothing);
+      expect(find.text('Page 1'), findsOneWidget);
+      expect(find.text('Page 2'), findsNothing);
+
+      await tester.tap(find.text('Page 1'));
+      await tester.pumpWidget(tree);
+
+      // Check that the second custom page is visible
+      expect(find.text('TEST 1'), findsOneWidget);
+      // Check that the first page is no longer visible
+      expect(find.text('TEST 0'), findsNothing);
+      // Check that the last page is still not visible
+      expect(find.text('TEST 2'), findsNothing);
+      // Check that the correct label for the next page is visible
+      expect(find.text('Page 0'), findsNothing);
+      expect(find.text('Page 1'), findsNothing);
+      expect(find.text('Page 2'), findsOneWidget);
+
+      await tester.tap(find.text('Page 2'));
+      await tester.pumpWidget(tree);
+
+      // Check that the last custom page is visible
+      expect(find.text('TEST 2'), findsOneWidget);
+      // Check that the first page is still not visible
+      expect(find.text('TEST 0'), findsNothing);
+      // Check that the middle page is no longer visible
+      expect(find.text('TEST 1'), findsNothing);
+      // Check that the correct label for the next page is visible
+      expect(find.text('Page 0'), findsOneWidget);
+      expect(find.text('Page 1'), findsNothing);
+      expect(find.text('Page 2'), findsNothing);
+
+      await tester.tap(find.text('Page 0'));
+      await tester.pumpWidget(tree);
+
+      // Check that we've wrapped around and the first custom page is visible
+      expect(find.text('TEST 0'), findsOneWidget);
+      // Check that the middle page is still not visible
+      expect(find.text('TEST 1'), findsNothing);
+      // Check that the last page is no longer visible
+      expect(find.text('TEST 2'), findsNothing);
+      // Check that the correct label for the next page is visible
+      expect(find.text('Page 0'), findsNothing);
+      expect(find.text('Page 1'), findsOneWidget);
+      expect(find.text('Page 2'), findsNothing);
+    },
+  );
+}


### PR DESCRIPTION
## Description

* **BREAKING**: `bool secondPage` has been replaced with `int page` in `MathFieldEditingController` to allow for more than two pages.
* Adds support for custom keyboard pages using the new `customPages` attribute that takes a list of `CustomButtonPage`s. 
  * Each `CustomButtonPage` takes a `List<List<KeyboardButtonConfig>>` as well as an optional `label` or `icon` to be shown using the `PageButtonConfig`. 
  * The existing pages were wrapped in this class.
* Adds a `fontSize` attribute to `MathKeyboard` and a `keyboardButtonFontSize` attribute to `MathField` to allow the font size of the keyboard buttons to be adjusted.
* Adds a `heightFactor` attribute to `KeyboardButtonConfig` to allow for customization of the height of keyboard rows.
* Adds widget tests for `MathKeyboard` to test the functionality of custom and default pages on the keyboard.


## Related issues & PRs

None

## Checklist

*Remove `If [...]` items that do not apply to your PR.*

- [x] I have made myself familiar with the CaTeX
      [contributing guide](https://github.com/simpleclub/math_keyboard/blob/master/CONTRIBUTING.md).
- [x] I added a PR description.
- [x] I linked all related issues and PRs I could find (no links if there are none).
- [x] If this PR changes anything about the main `math_keyboard` or `example` package
      (also README etc.), I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change
      on its own is not worth an update).
- [x] If this PR includes a notable change in the `math_keyboard` package, I updated the version
        according to [Dart's semantic versioning](https://stackoverflow.com/questions/66201337/how-do-dart-package-versions-work-how-should-i-version-my-flutter-plugins/66201338#66201338).
- [x] If there is new functionality in code, I added tests covering all my additions.
- [ ] All required checks pass.
