### PR TITLE
feat: Add additional TeXArg types

### DIFF
--- a/math_keyboard/CHANGELOG.md
+++ b/math_keyboard/CHANGELOG.md
@@ -1,3 +1,7 @@
+## FUTURE VERSION
+
+* Adds additional `TeXArg` types `parentheses_lr`, `caret_braces`, and `underscore_braces`.
+
 ## 0.2.1
 
 * Added Android support to the demo project.

--- a/math_keyboard/lib/src/foundation/node.dart
+++ b/math_keyboard/lib/src/foundation/node.dart
@@ -149,10 +149,16 @@ class TeXFunction extends TeX {
     switch (type) {
       case TeXArg.braces:
         return '{';
+      case TeXArg.underscore_braces:
+        return '_{';
+      case TeXArg.caret_braces:
+        return '^{';
       case TeXArg.brackets:
         return '[';
-      default:
+      case TeXArg.parentheses:
         return '(';
+      case TeXArg.parentheses_lr:
+        return r'\left(';
     }
   }
 
@@ -160,11 +166,15 @@ class TeXFunction extends TeX {
   String closingChar(TeXArg type) {
     switch (type) {
       case TeXArg.braces:
+      case TeXArg.underscore_braces:
+      case TeXArg.caret_braces:
         return '}';
       case TeXArg.brackets:
         return ']';
-      default:
+      case TeXArg.parentheses:
         return ')';
+      case TeXArg.parentheses_lr:
+        return r'\right)';
     }
   }
 
@@ -238,6 +248,18 @@ enum TeXArg {
   /// In most of the cases, braces will be used. (E.g arguments of fractions).
   braces,
 
+  /// _{ }
+  ///
+  /// This allows you to define subscript arguments on functions that support
+  /// it (like summation)
+  underscore_braces,
+
+  /// ^{ }
+  ///
+  /// This allows you to define superscript arguments on functions that support
+  /// it (like summation)
+  caret_braces,
+
   /// [ ]
   ///
   /// Brackets are only used for the nth root at the moment.
@@ -249,4 +271,10 @@ enum TeXArg {
   /// for functions like sin, cos, tan, etc. as well, so the user doesn't have
   /// to close the parentheses manually.
   parentheses,
+
+  /// \left( \right)
+  ///
+  /// These parentheses automatically expand to match the size of their content,
+  /// making them more visually appealing in most cases.
+  parentheses_lr,
 }

--- a/math_keyboard/lib/src/foundation/tex2math.dart
+++ b/math_keyboard/lib/src/foundation/tex2math.dart
@@ -65,10 +65,18 @@ class TeXParser {
         (string(r'\frac') | string(r'\log')).map((v) => [v, 'f']);
     final function = simpleFunction | otherFunction | sqrt | nrt;
 
-    final lp = (string('(') | char('{') | string(r'\left|') | char('['))
+    final lp = (string('(') |
+            char('{') |
+            string(r'\left|') |
+            char('[') |
+            string(r'\left('))
         .map((v) => [v, 'l']);
 
-    final rp = (string(')') | char('}') | string(r'\right|') | char(']'))
+    final rp = (string(')') |
+            char('}') |
+            string(r'\right|') |
+            char(']') |
+            string(r'\right)'))
         .map((v) => [v, 'r']);
 
     final plus = char('+').map((v) => [
@@ -170,9 +178,11 @@ class TeXParser {
           case 'l':
             // In case there is a closing parenthesis directly followed by an
             // opening one, some further checks are necessary.
-            if (_stream[i][0] == ')' && _stream[i + 1][0] == '(') {
+            if ((_stream[i][0] == ')' || _stream[i][0] == r'\right)') &&
+                (_stream[i + 1][0] == '(' || _stream[i + 1][0] == r'\left(')) {
               insertTimes = true;
-            } else if (_stream[i][0] == '}' && _stream[i + 1][0] == '(') {
+            } else if (_stream[i][0] == '}' &&
+                (_stream[i + 1][0] == '(' || _stream[i + 1][0] == r'\left(')) {
               // This case is unfavorable. If the '}' closes the second argument
               // of a fraction or marks the end of an exponent, we want to
               // insert 'times'. However, if '}' closes the base argument of a


### PR DESCRIPTION
## Description

Adds additional arguments to `TeXArg` to allow for more advanced customization and features.

For example, using a combination of `TeXArg.underscore_braces`, `TeXArg.caret_braces`, and `TeXArg.braces`, a user could implement a keyboard button that allows the user to type an integral, summation, or product.

Or, using the new `TeXArg.parentheses_lr`, a user can add more visually appealing parentheses as an argument to a keyboard button.

## Related issues & PRs

Fixes #38 

## Checklist

*Remove `If [...]` items that do not apply to your PR.*

- [x] I have made myself familiar with the CaTeX
      [contributing guide](https://github.com/simpleclub/math_keyboard/blob/master/CONTRIBUTING.md).
- [x] I added a PR description.
- [x] I linked all related issues and PRs I could find (no links if there are none).
- [x] If this PR changes anything about the main `math_keyboard` or `example` package
      (also README etc.), I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change
      on its own is not worth an update).
- [x] All required checks pass.
