### PR TITLE
feat: Add no brace parse & show braket flag

### DIFF
--- a/math_keyboard/lib/src/foundation/tex2math.dart
+++ b/math_keyboard/lib/src/foundation/tex2math.dart
@@ -42,11 +42,15 @@ class TeXParser {
         .map(num.parse);
 
     final pi = (string('{') & string(r'\pi') & string('}')).map((a) => math.pi);
+    final pi2 = string(r'\pi').map((a) => math.pi);
     final e = (string('{') & string('e') & string('}')).map((a) => math.e);
+    final e2 = string('e').map((a) => math.e);
     final variable =
         (string('{') & letter().plus().flatten() & string('}')).pick(1);
+    final variable2 = letter().plus().flatten();
 
-    final basic = (number | pi | e | variable).map((v) => [v, 'b']);
+    final basic = (number | pi | e | variable | pi2 | e2 | variable2)
+        .map((v) => [v, 'b']);
 
     final sqrt =
         (string(r'\sqrt') & char('{').and()).map((v) => [r'\sqrt', 'f']);

--- a/math_keyboard/lib/src/widgets/math_field.dart
+++ b/math_keyboard/lib/src/widgets/math_field.dart
@@ -672,9 +672,10 @@ class _FieldPreview extends StatelessWidget {
 /// A controller for an editable math field.
 class MathFieldEditingController extends ChangeNotifier {
   /// Constructs a [MathKeyboardViewModel].
-  MathFieldEditingController() {
+  MathFieldEditingController({bool? showBracket}) {
     currentNode = root;
     currentNode.setCursor();
+    this.showBracket = showBracket ?? true;
   }
 
   /// Type of the Keyboard.
@@ -685,6 +686,8 @@ class MathFieldEditingController extends ChangeNotifier {
 
   /// The block the user is currently in.
   late TeXNode currentNode;
+
+  bool showBracket = true;
 
   /// Returns the current editing value (expression), which requires temporarily
   /// removing the cursor. When [placeholderWhenEmpty] is true, a TeX \Box
@@ -706,7 +709,10 @@ class MathFieldEditingController extends ChangeNotifier {
   /// Clears the current value and sets it to the [expression] equivalent.
   void updateValue(Expression expression) {
     try {
-      root = convertMathExpressionToTeXNode(expression);
+      root = convertMathExpressionToTeXNode(
+        mathExpression: expression,
+        showBracket: showBracket,
+      );
     } catch (e) {
       throw Exception('Unsupported input expression $expression ($e)');
     }

--- a/math_keyboard/test/foundation/math2tex_test.dart
+++ b/math_keyboard/test/foundation/math2tex_test.dart
@@ -9,12 +9,14 @@ import 'package:math_keyboard/src/foundation/tex2math.dart';
 void main() {
   group('constants', () {
     test('pi', () {
-      final node = convertMathExpressionToTeXNode(Parser().parse('$pi'));
+      final node = convertMathExpressionToTeXNode(
+          mathExpression: Parser().parse('$pi'), showBracket: true);
       expect(node.children[0].expression, r'{\pi}');
     });
 
     test('e', () {
-      final node = convertMathExpressionToTeXNode(Parser().parse('$e'));
+      final node = convertMathExpressionToTeXNode(
+          mathExpression: Parser().parse('$e'), showBracket: true);
       expect(node.children[0].expression, r'{e}');
     });
 
@@ -22,7 +24,21 @@ void main() {
       const tex = r'23+{\pi}+{x}';
       const exp = '23+$pi+x';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
+                .buildTeXString(cursorColor: null))
+            .parse()
+            .toString(),
+        TeXParser(tex).parse().toString(),
+      );
+    });
+
+    test('no brace pi', () {
+      const tex = r'23+\pi+{x}';
+      const exp = '23+$pi+x';
+      expect(
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -34,7 +50,34 @@ void main() {
       const tex = '{x}+{e}^2';
       const exp = 'x+$e^2';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
+                .buildTeXString(cursorColor: null))
+            .parse()
+            .toString(),
+        TeXParser(tex).parse().toString(),
+      );
+    });
+
+    test('no brace e2', () {
+      const tex = '{x}+e^2';
+      const exp = 'x+$e^2';
+      expect(
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
+                .buildTeXString(cursorColor: null))
+            .parse()
+            .toString(),
+        TeXParser(tex).parse().toString(),
+      );
+    });
+
+    test('no brace x^2', () {
+      const tex = 'x^2';
+      const exp = 'x^2';
+      expect(
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -48,7 +91,8 @@ void main() {
       const tex = r'23\cdot{x}';
       const exp = '23*x';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -60,7 +104,8 @@ void main() {
       const tex = r'23\times({var})';
       const exp = '23*var';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -72,7 +117,8 @@ void main() {
       const tex = '23{c}';
       const exp = '23*c';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -86,7 +132,8 @@ void main() {
       const tex = r'\frac{1}{{x}}';
       const exp = '1/x';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -98,7 +145,8 @@ void main() {
       const tex = r'\frac{1}{\frac{{x}}{2}}';
       const exp = '1/(x/2)';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -112,7 +160,8 @@ void main() {
       const tex = r'0.001\times{x}';
       const exp = '0.001*x';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -126,7 +175,8 @@ void main() {
       const tex = r'2\times\sin({x})';
       const exp = '2*sin(x)';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -138,7 +188,8 @@ void main() {
       const tex = r'\sin^{-1}({x})';
       const exp = 'arcsin(x)';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -150,7 +201,8 @@ void main() {
       const tex = r'\cos({x})';
       const exp = 'cos(x)';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -162,7 +214,8 @@ void main() {
       const tex = r'\cos^{-1}({x})';
       const exp = 'arccos(x)';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -174,7 +227,8 @@ void main() {
       const tex = r'\tan({y})';
       const exp = 'tan(y)';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -186,7 +240,8 @@ void main() {
       const tex = r'\tan^{-1}({y})';
       const exp = 'arctan(y)';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -200,7 +255,8 @@ void main() {
       const tex = r'2 \times  \sqrt{{x}}';
       const exp = '2*nrt(2,x)';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -214,7 +270,8 @@ void main() {
       const tex = r'\log_{2.0}({x})';
       const exp = 'log(2,x)';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -226,7 +283,8 @@ void main() {
       const tex = r'\log_{2.718281828459045}(2{x})';
       const exp = 'ln(2*x)';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -240,7 +298,8 @@ void main() {
       const tex = r'-(\frac{2 \times  \sqrt{ 16 }}{{x}^2})^2';
       const exp = '(0-((2*nrt(2,16))/(x^2))^2)';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),
@@ -252,7 +311,8 @@ void main() {
       const tex = r'\frac{3}{2}\cdot{e}^{\frac{1}{4}\cdot{x}}';
       const exp = '3/2*e^(1/4*x)';
       expect(
-        TeXParser(convertMathExpressionToTeXNode(Parser().parse(exp))
+        TeXParser(convertMathExpressionToTeXNode(
+                    mathExpression: Parser().parse(exp), showBracket: true)
                 .buildTeXString(cursorColor: null))
             .parse()
             .toString(),


### PR DESCRIPTION
## Description

Normarlly Latex foramt not use '{..}' (ex. Not! {x}^2, Like!!! x^2)
So i add additional parsing logic that don't have brace.
And Pass 'showBracket' parameter to Controller, Switch show braket in Textfield

## Related issues & PRs

*Links to issues and PRs that are related to your PR. Use [keywords] for issues if applicable.*

[keywords]: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

## Checklist

*Remove `If [...]` items that do not apply to your PR.*

- [x] I have made myself familiar with the CaTeX
      [contributing guide](https://github.com/simpleclub/math_keyboard/blob/master/CONTRIBUTING.md).
- [x] I added a PR description.
- [ ] I linked all related issues and PRs I could find (no links if there are none).
- [ ] If this PR changes anything about the main `math_keyboard` or `example` package
      (also README etc.), I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change
      on its own is not worth an update).
- [ ] If this PR includes a notable change in the `math_keyboard` package, I updated the version
        according to [Dart's semantic versioning](https://stackoverflow.com/questions/66201337/how-do-dart-package-versions-work-how-should-i-version-my-flutter-plugins/66201338#66201338).
- [ ] If there is new functionality in code, I added tests covering all my additions.
- [ ] All required checks pass.
