### PR TITLE
Added integration and differenciation

### DIFF
--- a/math_keyboard/CHANGELOG.md
+++ b/math_keyboard/CHANGELOG.md
@@ -1,69 +1,73 @@
+## UPCOMING RELEASE
+
+- keyboard now supports both integration and derivation
+
 ## 0.3.0
 
-* Updated all dependencies
-* Require flutter: `'>=3.22.2'` 
+- Updated all dependencies
+- Require flutter: `'>=3.22.2'`
 
 ## 0.2.1
 
-* Added Android support to the demo project.
-* Closes keyboard on Android hardware back button press.
+- Added Android support to the demo project.
+- Closes keyboard on Android hardware back button press.
 
 ## 0.2.0
 
-* Bumped `flutter_math_fork` and `intl`.
+- Bumped `flutter_math_fork` and `intl`.
 
 ## 0.1.9
 
-* Exposes `MathKeyboards` and adds padding and hover effects to it.
+- Exposes `MathKeyboards` and adds padding and hover effects to it.
 
 ## 0.1.8
 
-* Return empty string instead of \\Box when field is empty
+- Return empty string instead of \\Box when field is empty
 
 ## 0.1.7
 
-* Updated Petitparser dependency.
+- Updated Petitparser dependency.
 
 ## 0.1.6
 
-* Cleared Flutter 3.0.x warnings.
+- Cleared Flutter 3.0.x warnings.
 
 ## 0.1.5
 
-* Updated field cursor using `\cursor` function from `flutter_math_fork 0.6.2`.
+- Updated field cursor using `\cursor` function from `flutter_math_fork 0.6.2`.
 
 ## 0.1.4+1
 
-* Bumped `flutter_math_fork`.
+- Bumped `flutter_math_fork`.
 
 ## 0.1.4
 
-* Fixed missing implicit times operator between a closing and an opening parenthesis. 
+- Fixed missing implicit times operator between a closing and an opening parenthesis.
 
 ## 0.1.3
 
-* Added new symbols icon for functions button.
-* Added fraction button to second keyboard page.
+- Added new symbols icon for functions button.
+- Added fraction button to second keyboard page.
 
 ## 0.1.2
 
-* Bumped `flutter_math_fork`.
+- Bumped `flutter_math_fork`.
 
 ## 0.1.1+1
 
-* Fixed `numpadBackspace` breaking change.
-* Addressed `ThemeData.accentColor` deprecations.
+- Fixed `numpadBackspace` breaking change.
+- Addressed `ThemeData.accentColor` deprecations.
 
 ## 0.1.1
 
-* Unary minus support when converting to an expression.
-* Keep parentheses when initialising controller with an expression.
-* Added special cases for pi and e when initializing controller.
+- Unary minus support when converting to an expression.
+- Keep parentheses when initialising controller with an expression.
+- Added special cases for pi and e when initializing controller.
 
 ## 0.1.0+1
 
-* Fixed styling of commas as decimal separators.
+- Fixed styling of commas as decimal separators.
 
 ## 0.1.0
 
-* Initial public version.
+- Initial public version.

--- a/math_keyboard/lib/src/foundation/keyboard_button.dart
+++ b/math_keyboard/lib/src/foundation/keyboard_button.dart
@@ -204,6 +204,20 @@ final functionKeyboard = [
     ),
   ],
   [
+    const BasicKeyboardButtonConfig(
+      label: r'\int_{\Box}^{\Box} (\Box) dx',
+      value: r'\int',
+      asTex: true,
+      args: [TeXArg.undbraces, TeXArg.powbraces, TeXArg.parenthesesdx],
+    ),
+    const BasicKeyboardButtonConfig(
+      label: r'\frac{d}{dx} ({\Box})',
+      value: r'\frac{d}{dx}',
+      asTex: true,
+      args: [TeXArg.braces],
+    ),
+  ],
+  [
     const PageButtonConfig(flex: 3),
     const BasicKeyboardButtonConfig(
       label: '(',

--- a/math_keyboard/lib/src/foundation/node.dart
+++ b/math_keyboard/lib/src/foundation/node.dart
@@ -149,6 +149,10 @@ class TeXFunction extends TeX {
     switch (type) {
       case TeXArg.braces:
         return '{';
+      case TeXArg.powbraces:
+        return '^{';
+      case TeXArg.undbraces:
+        return '_{';
       case TeXArg.brackets:
         return '[';
       default:
@@ -161,8 +165,14 @@ class TeXFunction extends TeX {
     switch (type) {
       case TeXArg.braces:
         return '}';
+      case TeXArg.powbraces:
+        return '}';
+      case TeXArg.undbraces:
+        return '}';
       case TeXArg.brackets:
         return ']';
+      case TeXArg.parenthesesdx:
+        return r')  dx';
       default:
         return ')';
     }
@@ -233,6 +243,16 @@ enum NavigationState {
 
 /// How the argument is marked.
 enum TeXArg {
+  /// _{ }
+  ///
+  /// In most of the cases, braces will be used. (E.g arguments of fractions).
+  undbraces,
+
+  /// ^{ }
+  ///
+  /// In most of the cases, braces will be used. (E.g arguments of fractions).
+  powbraces,
+
   /// { }
   ///
   /// In most of the cases, braces will be used. (E.g arguments of fractions).
@@ -249,4 +269,9 @@ enum TeXArg {
   /// for functions like sin, cos, tan, etc. as well, so the user doesn't have
   /// to close the parentheses manually.
   parentheses,
+
+  /// ()
+  ///
+  /// A completely custom end just to make integration work properly
+  parenthesesdx,
 }

--- a/math_keyboard/lib/src/widgets/math_field.dart
+++ b/math_keyboard/lib/src/widgets/math_field.dart
@@ -621,6 +621,7 @@ class _FieldPreview extends StatelessWidget {
           '{${decimalSeparator(context)}}',
         );
 
+    print(tex);
     return ConstrainedBox(
       constraints: const BoxConstraints(
         minWidth: double.infinity,
@@ -825,12 +826,23 @@ class MathFieldEditingController extends ChangeNotifier {
     // The same applies for fractions.
     else if (tex == r'\frac') {
       addFrac(func);
+    } else if (tex == r'\int') {
+      addInt(func);
     } else {
       currentNode.addTeX(func);
       currentNode = func.argNodes.first;
     }
     currentNode.setCursor();
     notifyListeners();
+  }
+
+  /// Adds an integration to the current node
+  ///
+  void addInt(TeXFunction int) {
+    // were adding dx to the end of the integration function
+
+    currentNode.addTeX(int);
+    currentNode = int.argNodes.first;
   }
 
   /// Adds a pow to the current node

--- a/math_keyboard/lib/src/widgets/math_keyboard.dart
+++ b/math_keyboard/lib/src/widgets/math_keyboard.dart
@@ -309,7 +309,7 @@ class _Buttons extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: 230,
+      height: 280,
       child: AnimatedBuilder(
         animation: controller,
         builder: (context, child) {

--- a/math_keyboard_demo/lib/widgets/app.dart
+++ b/math_keyboard_demo/lib/widgets/app.dart
@@ -17,17 +17,24 @@ class _DemoAppState extends State<DemoApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: appTitle,
-      theme: ThemeData(
-        brightness: _darkMode ? Brightness.dark : Brightness.light,
-      ),
-      home: DemoScaffold(
-        onToggleBrightness: () {
-          setState(() {
-            _darkMode = !_darkMode;
-          });
-        },
-      ),
-    );
+        title: appTitle,
+        theme: ThemeData(
+          brightness: _darkMode ? Brightness.dark : Brightness.light,
+        ),
+        home: MyTest());
+  }
+}
+
+class MyTest extends StatefulWidget {
+  const MyTest({super.key});
+
+  @override
+  State<MyTest> createState() => _MyTestState();
+}
+
+class _MyTestState extends State<MyTest> {
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
   }
 }


### PR DESCRIPTION
## Description

Ive added a working implementation of both integration and differenciation into the existing keyboard. The ui seems a bit squished but i didnt want to add a new page. However it does fail in expression conversion simply becuase i didnt want to edit that code.

## Related issues & PRs

Its related to this [issue](https://github.com/simpleclub/math_keyboard/issues/34)

## Checklist

*Remove `If [...]` items that do not apply to your PR.*

- [x] I have made myself familiar with the CaTeX
      [contributing guide](https://github.com/simpleclub/math_keyboard/blob/master/CONTRIBUTING.md).
- [x ] I added a PR description.
- [ x] I linked all related issues and PRs I could find (no links if there are none).
- [x] If this PR changes anything about the main `math_keyboard` or `example` package
      (also README etc.), I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change
      on its own is not worth an update).
- [x] If this PR includes a notable change in the `math_keyboard` package, I updated the version
        according to [Dart's semantic versioning](https://stackoverflow.com/questions/66201337/how-do-dart-package-versions-work-how-should-i-version-my-flutter-plugins/66201338#66201338).
- [ ] If there is new functionality in code, I added tests covering all my additions.
- [ ] All required checks pass.

