### PR TITLE
Fix wasm cast

### DIFF
--- a/math_keyboard/CHANGELOG.md
+++ b/math_keyboard/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+* Workaround for dart2wasm [bug](https://github.com/dart-lang/sdk/issues/59782).
+
 ## 0.3.1
 
 * Updated README

--- a/math_keyboard/lib/src/foundation/tex2math.dart
+++ b/math_keyboard/lib/src/foundation/tex2math.dart
@@ -311,8 +311,8 @@ class TeXParser {
     final result = <Expression>[];
     Expression left;
     Expression right;
-    for (var i = 0; i < _outputStack.length; i++) {
-      switch (_outputStack[i]) {
+    for (final element in _outputStack) {
+      switch (element) {
         case '+':
           right = result.removeLast();
           left = result.removeLast();
@@ -391,11 +391,14 @@ class TeXParser {
             // ignore: empty_catches
           } catch (e) {}
           break;
+        // workaround for WASM casting bug, needs at least one non-string case
+        // remove when https://github.com/dart-lang/sdk/issues/59782 is fixed
+        case 0:
         default:
-          if (_outputStack[i] is String) {
-            result.add(Variable(_outputStack[i]));
+          if (element is String) {
+            result.add(Variable(element));
           } else {
-            result.add(Number(_outputStack[i]));
+            result.add(Number(element));
           }
       }
     }

--- a/math_keyboard/pubspec.yaml
+++ b/math_keyboard/pubspec.yaml
@@ -2,7 +2,7 @@ name: math_keyboard
 description: >-2
   Math expression editing using an on-screen software keyboard or physical keyboard input in a
   typeset input field in Flutter.
-version: 0.3.1
+version: 0.3.2
 homepage: https://github.com/simpleclub/math_keyboard/tree/main/math_keyboard
 
 environment:
@@ -15,7 +15,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  flutter_math_fork: ^0.7.2
+  flutter_math_fork: ^0.7.3
   holding_gesture: ^1.2.0
   intl: ^0.19.0
   math_expressions: ^2.5.0


### PR DESCRIPTION
## Description

This PR adds a workaround for a bug present in the current dart2wasm compiler.
Switch statements that only contain cases matching the same type wrongfully try to cast the value to that type.
This breaks our checks against certain strings when parsing tex to math.

## Related issues & PRs

Resolves dart-lang/sdk#59782

## Checklist

*Remove `If [...]` items that do not apply to your PR.*

- [x] I have made myself familiar with the CaTeX
      [contributing guide](https://github.com/simpleclub/math_keyboard/blob/master/CONTRIBUTING.md).
- [x] I added a PR description.
- [x] I linked all related issues and PRs I could find (no links if there are none).
- [x] If this PR changes anything about the main `math_keyboard` or `example` package
      (also README etc.), I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change
      on its own is not worth an update).
- [x] If this PR includes a notable change in the `math_keyboard` package, I updated the version
        according to [Dart's semantic versioning](https://stackoverflow.com/questions/66201337/how-do-dart-package-versions-work-how-should-i-version-my-flutter-plugins/66201338#66201338).
- [ ] All required checks pass.
