### PR TITLE
Added workflow permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,6 @@
 name: checks
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,4 +1,7 @@
 name: greetings
+permissions:
+  issues: write
+  pull-requests: write
 
 on:
   - pull_request_target

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -1,4 +1,7 @@
 name: licenses
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   schedule:

--- a/.github/workflows/pana.yml
+++ b/.github/workflows/pana.yml
@@ -1,4 +1,6 @@
 name: pana
+permissions:
+  contents: read
 
 on:
   pull_request_target:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish to pub.dev
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/web_deploy.yml
+++ b/.github/workflows/web_deploy.yml
@@ -1,4 +1,6 @@
 name: web demo
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
## Description

Add explicit GitHub Actions token permissions to all workflows to follow the principle of least privilege and align with GitHub’s permission hardening. This reduces CI security surface and prevents permission-related warnings/failures.

Per-workflow changes:
- `checks.yml`: `permissions: contents: read`
- `greetings.yml`: `permissions: issues: write, pull-requests: write`
- `licenses.yml`: `permissions: contents: write, pull-requests: write`
- `pana.yml`: `permissions: contents: read`
- `publish.yml`: `permissions: contents: read`
- `web_deploy.yml`: `permissions: contents: write`

No production code changes, no version bumps, and no test updates.

## Related issues & PRs

None.

## Checklist

- [x] I added a PR description.
- [x] I linked all related issues and PRs I could find (none).
- [ ] All required checks pass.