### PR TITLE
ci: update web demo deploy workflow to maintained action versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2.3.3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.channel }}
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2.3.3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.channel }}

--- a/.github/workflows/web_deploy.yml
+++ b/.github/workflows/web_deploy.yml
@@ -20,10 +20,10 @@ jobs:
     name: deployment of math_keyboard_demo
 
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: subosito/flutter-action@v1.4.0
+      - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
 
@@ -36,11 +36,10 @@ jobs:
           touch ".nojekyll"
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: math_keyboard_demo/build/web
-          GIT_CONFIG_NAME: simpleclub-bot
-          GIT_CONFIG_EMAIL: developers@simpleclub.com
-          COMMIT_MESSAGE: Deploy math_keyboard_demo web page
+          branch: gh-pages
+          folder: math_keyboard_demo/build/web
+          git-config-name: simpleclub-bot
+          git-config-email: developers@simpleclub.com
+          commit-message: Deploy math_keyboard_demo web page


### PR DESCRIPTION
## What

The **web demo** workflow has been failing on \`main\` (last run: [31783312641](https://github.com/simpleclub/math_keyboard/actions/runs/31783312641)) because \`subosito/flutter-action@v1.4.0\` installs a 2021-era Flutter (Dart 2.13.1), while the demo requires SDK \`>=3.3.0\` — so \`pub get\` fails before the build even starts.

## Changes

- \`subosito/flutter-action\`: \`v1.4.0\` → \`v2\` (same version \`checks.yml\` already uses), fixing the Dart SDK conflict
- \`actions/checkout\`: \`v2.3.4\` → \`v4\` (Node 12/20-era action, deprecated on current runners)
- \`JamesIves/github-pages-deploy-action\`: \`3.7.1\` → \`v4\`, migrating inputs to the v4 names (\`branch\`/\`folder\`/\`git-config-*\`); v4 uses the default \`GITHUB_TOKEN\` automatically, and the job already has \`contents: write\`

Verified locally: \`flutter build web\` of \`math_keyboard_demo\` succeeds on current stable.

Since this workflow file is in its own path filter, merging this PR re-triggers the deploy, bringing the redesigned 0.4.0 keyboard to the live demo page.